### PR TITLE
Modify Makefile to build on kolossus from fresh clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean
 
 CXX=g++
-INCLUDES=-Iekg/vg -Iekg/vg/gssw/src -Iekg/vg/gcsa2 -Iekg/vg/cpp -Iekg/vg/sdsl-lite/install/include -Iekg/vg/vcflib/src -Iekg/vg/vcflib -Iekg/vg/vcflib/tabixpp/htslib -Iekg/vg/progress_bar -Iekg/vg/lru_cache -Iekg/vg/fastahack -Iekg/vg/xg -Iekg/vg/xg/sdsl-lite/build/include -Ibenedictpaten/sonLib/C/inc
+INCLUDES=-Iekg/vg -Iekg/vg/gssw/src -Iekg/vg/protobuf/build/include -Iekg/vg/gcsa2 -Iekg/vg/cpp -Iekg/vg/sdsl-lite/install/include -Iekg/vg/vcflib/src -Iekg/vg/vcflib -Iekg/vg/vcflib/tabixpp/htslib -Iekg/vg/progress_bar -Iekg/vg/sparsehash/build/include -Iekg/vg/lru_cache -Iekg/vg/fastahack -Iekg/vg/xg -Iekg/vg/xg/sdsl-lite/build/include -Ibenedictpaten/sonLib/C/inc
 CXXFLAGS=-O3 -std=c++11 -fopenmp -g $(INCLUDES)
 LDSEARCH=-Lekg/vg -Lekg/vg/xg -Lekg/vg/xg/sdsl-lite/build/lib -Lekg/vg/xg/sdsl-lite/build/external/libdivsufsort/lib
 LDFLAGS=-lm -lpthread -lz -ldivsufsort -ldivsufsort64 -ljansson $(LDSEARCH)
@@ -27,7 +27,7 @@ $(LIBPROTOBUF): $(LIBVG)
 
 $(LIBVG):
 	cd ekg/vg && $(MAKE) libvg.a
-	
+
 # This builds out to the sonLib lib directory for some reason
 $(LIBPINCHESANDCACTI): $(LIBSONLIB)
 	cd benedictpaten/pinchesAndCacti && $(MAKE)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CXX=g++
 INCLUDES=-Iekg/vg -Iekg/vg/gssw/src -Iekg/vg/protobuf/build/include -Iekg/vg/gcsa2 -Iekg/vg/cpp -Iekg/vg/sdsl-lite/install/include -Iekg/vg/vcflib/src -Iekg/vg/vcflib -Iekg/vg/vcflib/tabixpp/htslib -Iekg/vg/progress_bar -Iekg/vg/sparsehash/build/include -Iekg/vg/lru_cache -Iekg/vg/fastahack -Iekg/vg/xg -Iekg/vg/xg/sdsl-lite/build/include -Ibenedictpaten/sonLib/C/inc
 CXXFLAGS=-O3 -std=c++11 -fopenmp -g $(INCLUDES)
 LDSEARCH=-Lekg/vg -Lekg/vg/xg -Lekg/vg/xg/sdsl-lite/build/lib -Lekg/vg/xg/sdsl-lite/build/external/libdivsufsort/lib
-LDFLAGS=-lm -lpthread -lz -ldivsufsort -ldivsufsort64 -ljansson $(LDSEARCH)
+LDFLAGS=-lm -lpthread -lz -lbz2 -lsnappy -ldivsufsort -ldivsufsort64 -ljansson $(LDSEARCH)
 LIBVG=ekg/vg/libvg.a
 LIBXG=ekg/vg/xg/libxg.a
 LIBPROTOBUF=ekg/vg/protobuf/libprotobuf.a
@@ -24,6 +24,8 @@ VGLIBS=$(LIBVG) $(LIBXG) $(LIBVCFLIB) $(LIBGSSW) $(LIBSNAPPY) $(LIBROCKSDB) $(LI
 SYS=$(shell uname -s)
 ifeq (${SYS},Darwin)
 	LDFLAGS:=$(LDFLAGS) -L/opt/local/lib/ # needed for macports jansson
+else
+	LDFLAGS:=$(LDFLAGS) -lrt
 endif
 
 all: corg
@@ -35,6 +37,9 @@ $(LIBPROTOBUF): $(LIBVG)
 $(LIBVG):
 	cd ekg/vg && $(MAKE) libvg.a
 
+$(LIBXG): $(LIBVG)
+	cd ekg/vg && $(MAKE) xg/libxg.a
+
 # This builds out to the sonLib lib directory for some reason
 $(LIBPINCHESANDCACTI): $(LIBSONLIB)
 	cd benedictpaten/pinchesAndCacti && $(MAKE)
@@ -43,9 +48,9 @@ $(LIBSONLIB):
 	cd benedictpaten/sonLib && $(MAKE)
 
 # Needs XG to be built for the protobuf headers
-main.o: $(LIBXG)
+main.o: $(LIBXG) $(LIBPINCESANDCACTI)
 
-corg: main.o embeddedGraph.o $(LIBPINCHESANDCACTI) $(LIBSONLIB) $(VGLIBS)
+corg: main.o embeddedGraph.o $(LIBPINCHESANDCACTI) $(LIBSONLIB) $(VGLIBS) 
 	$(CXX) $^ -o $@ $(CXXFLAGS) $(LDFLAGS)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@ LIBGCSA2=ekg/vg/gcsa2/libgcsa2.a
 LIBVCFLIB=ekg/vg/vcflib/libvcflib.a
 VGLIBS=$(LIBVG) $(LIBXG) $(LIBVCFLIB) $(LIBGSSW) $(LIBSNAPPY) $(LIBROCKSDB) $(LIBHTS) $(LIBGCSA2) $(LIBSDSL) $(LIBPROTOBUF)
 
+#Some little adjustments to build on OSX
+#(tested with gcc4.9 and jansson installed from MacPorts)
+SYS=$(shell uname -s)
+ifeq (${SYS},Darwin)
+	LDFLAGS:=$(LDFLAGS) -L/opt/local/lib/ # needed for macports jansson
+endif
+
 all: corg
 
 $(LIBSDSL): $(LIBVG)


### PR DESCRIPTION
I had a number of problems building on kolossus.  This PR has some hacks I made so that

```
 git clone git@github.com:glennhickey/corg.git --recursive && cd corg && make
```

runs without error (using /cluster/home/anovak/.local/bin/g++).  It also helps build on my Mac, but that doesn't still run flawlessly.  There are issues with the new protobuf and, it seems, the make libvg/xg.  Can be worked around, and probably better tackled within vg.   
